### PR TITLE
Handle s3 errors for non-existent files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ Create an s3 bucket to store current antivirus definitions.  This
 provides the fastest download speeds for the scanner.  This bucket can
 be kept as private.  
 
-In this bucket, create a directory named clamav_defs (this is the default name of the directory, can be changed at the environment variables)
- copy main.cvd | daily.cvd | bytecode.cvd from [https://www.clamav.net/downloads](https://www.clamav.net/downloads)
- this is needed for the first run of the script.
-
 To allow public access, useful for other accounts,
 add the following policy to the bucket.
 


### PR DESCRIPTION
Fixes #3 by not handling s3 errors for non-existent files and not attempting to download non-existent files.