### PR TITLE
Log S3 object version information for extra security + allow processing control for versioned buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ the table below for reference.
 | CLAMSCAN_PATH | Path to ClamAV clamscan binary | ./bin/clamscan | No |
 | FRESHCLAM_PATH | Path to ClamAV freshclam binary | ./bin/freshclam | No |
 | DATADOG_API_KEY | API Key for pushing metrics to DataDog (optional) | | No |
+| AV_PROCESS_ORIGINAL_VERSION_ONLY | Controls that only original version of an S3 key is processed (if bucket versioning is enabled) | False | No |
 
 ## License
 

--- a/common.py
+++ b/common.py
@@ -29,6 +29,7 @@ AV_TIMESTAMP_METADATA = os.getenv("AV_TIMESTAMP_METADATA", "av-timestamp")
 CLAMAVLIB_PATH = os.getenv("CLAMAVLIB_PATH", "./bin")
 CLAMSCAN_PATH = os.getenv("CLAMSCAN_PATH", "./bin/clamscan")
 FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
+AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv("AV_PROCESS_ORIGINAL_VERSION_ONLY", "False")
 
 AV_DEFINITION_FILENAMES = ["main.cvd","daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
 

--- a/scan.py
+++ b/scan.py
@@ -78,6 +78,7 @@ def sns_start_scan(s3_object):
     message = {
         "bucket": s3_object.bucket_name,
         "key": s3_object.key,
+        "version": s3_object.version_id,
         AV_SCAN_START_METADATA: True,
         AV_TIMESTAMP_METADATA: datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC")
     }
@@ -94,6 +95,7 @@ def sns_scan_results(s3_object, result):
     message = {
         "bucket": s3_object.bucket_name,
         "key": s3_object.key,
+        "version": s3_object.version_id,
         AV_STATUS_METADATA: result,
         AV_TIMESTAMP_METADATA: datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC")
     }

--- a/scan.py
+++ b/scan.py
@@ -20,6 +20,7 @@ import metrics
 import urllib
 from common import *
 from datetime import datetime
+from distutils.util import strtobool
 
 ENV = os.getenv("ENV", "")
 
@@ -32,6 +33,25 @@ def event_object(event):
         raise Exception("Unable to retrieve object from event.")
     return s3.Object(bucket, key)
 
+def verify_s3_object_version(s3_object):
+    # validate that we only process the original version of a file, if asked to do so
+    # security check to disallow processing of a new (possibly infected) object version
+    # while a clean initial version is getting processed
+    # downstream services may consume latest version by mistake and get the infected version instead
+    if str_to_bool(AV_PROCESS_ORIGINAL_VERSION_ONLY):
+        bucketVersioning = s3.BucketVersioning(s3_object.bucket_name)
+        if (bucketVersioning.status == "Enabled"):
+            bucket = s3.Bucket(s3_object.bucket_name)
+            versions = list(bucket.object_versions.filter(Prefix=s3_object.key))
+            if len(versions) > 1:
+                print("Detected multiple object versions in %s.%s, aborting processing" % (s3_object.bucket_name, s3_object.key))
+                raise Exception("Detected multiple object versions in %s.%s, aborting processing" % (s3_object.bucket_name, s3_object.key))
+            else:
+                print("Detected only 1 object versions in %s.%s, proceeding with processing" % (s3_object.bucket_name, s3_object.key))
+        else:
+            # misconfigured bucket, left with no or suspended versioning
+            print("Unable to implement check for original version, as versioning is not enabled in bucket %s" % s3_object.bucket_name)
+            raise Exception("Object versioning is not enabled in bucket %s" % s3_object.bucket_name)
 
 def download_s3_object(s3_object, local_prefix):
     local_path = "%s/%s/%s" % (local_prefix, s3_object.bucket_name, s3_object.key)
@@ -112,6 +132,7 @@ def lambda_handler(event, context):
     print("Script starting at %s\n" %
           (start_time.strftime("%Y/%m/%d %H:%M:%S UTC")))
     s3_object = event_object(event)
+    verify_s3_object_version(s3_object)
     sns_start_scan(s3_object)
     file_path = download_s3_object(s3_object, "/tmp")
     clamav.update_defs_from_s3(AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX)
@@ -129,3 +150,6 @@ def lambda_handler(event, context):
         pass
     print("Script finished at %s\n" %
           datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC"))
+
+def str_to_bool(s):
+    return bool(strtobool(str(s)))

--- a/scan.py
+++ b/scan.py
@@ -47,7 +47,7 @@ def verify_s3_object_version(s3_object):
                 print("Detected multiple object versions in %s.%s, aborting processing" % (s3_object.bucket_name, s3_object.key))
                 raise Exception("Detected multiple object versions in %s.%s, aborting processing" % (s3_object.bucket_name, s3_object.key))
             else:
-                print("Detected only 1 object versions in %s.%s, proceeding with processing" % (s3_object.bucket_name, s3_object.key))
+                print("Detected only 1 object version in %s.%s, proceeding with processing" % (s3_object.bucket_name, s3_object.key))
         else:
             # misconfigured bucket, left with no or suspended versioning
             print("Unable to implement check for original version, as versioning is not enabled in bucket %s" % s3_object.bucket_name)


### PR DESCRIPTION
During out security review, we identified a potential security hote:

* user uploads file to S3 bucket/key, triggering virus scanning
* while lambda is running, user uploads a new version of the same file, but infected
* when first virus scanning lambda completes with success, downstream consumers may access latest version of the key, giving them instead the infected file (if it's own lambda has not finished scanning yet)

One of the first safeguards is to explicitly add a *version* field to all the SNS messages to explicitly indicate the object version on versioned buckets.

If bucket does not implement versioning (rather dangerous). it will be null.