### PR TITLE
Fix to build with latest amazon Linux

### DIFF
--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -27,10 +27,13 @@ virtualenv env
 pip install --no-cache-dir -r requirements.txt
 
 pushd /tmp
-yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update
+yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c libtool-ltdl pcre2
 rpm2cpio clamav-0*.rpm | cpio -idmv
 rpm2cpio clamav-lib*.rpm | cpio -idmv
 rpm2cpio clamav-update*.rpm | cpio -idmv
+rpm2cpio json-c-*.rpm | cpio -idmv
+rpm2cpio libtool-ltdl-*.rpm | cpio -idmv
+rpm2cpio pcre2-*.rpm | cpio -idmv
 popd
 mkdir -p bin
 cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* bin/.

--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -19,7 +19,8 @@ lambda_output_file=/opt/app/build/lambda.zip
 set -e
 
 yum update -y
-yum install -y cpio python27-pip zip
+yum install -y python2-pip zip yum-utils
+yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 pip install --no-cache-dir virtualenv
 virtualenv env
 . env/bin/activate


### PR DESCRIPTION
PR enables build to succeed with latest amazon Linux.
EPEL is required for ClamAv.
Copies missing libs.
Tested with both local SAM & in AWS.