### PR TITLE
Update instructions to match new Lambda config pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,19 +74,11 @@ this every 3 hours to stay protected from the latest threats.
 1. Create the archive using the method in the
  [Build from Source](#build-from-source) section.
 2. From the AWS Lambda Dashboard, click **Create function**
-3. Choose **Author from scratch** on the *Select Blueprint* page
-4. Create a new trigger of type **CloudWatch Event** using `rate(3 hours)`
-for the **Schedule expression**.  Be sure to check **Enable trigger**
-5. Name your function `bucket-antivirus-update` when prompted on the
+3. Choose **Author from scratch** on the *Create function* page
+4. Name your function `bucket-antivirus-update` when prompted on the
 *Configure function* step.
-6. Set *Runtime* to `Python 2.7`
-7. Choose **Upload a ZIP file** for *Code entry type* and select the archive
-downloaded in step 1.
-8. Add a single environment variable named `AV_DEFINITION_S3_BUCKET`
-and set its value to the name of the bucket created to store your AV
-definitions.
-9. Set *Lambda handler* to `update.lambda_handler`
-10.  Create a new role name `bucket-antivirus-update` that uses the
+5. Set *Runtime* to `Python 2.7`
+6.  Create a new role name `bucket-antivirus-update` that uses the
 following policy document
 ```json
 {
@@ -115,9 +107,18 @@ following policy document
    ]
 }
 ```
-11. Before finishing, set *Timeout* to **5 minutes** and *Memory* to
+7. Click next to go to the Configuration page
+8. Add a trigger from the left of **CloudWatch Event** using `rate(3 hours)`
+for the **Schedule expression**.  Be sure to check **Enable trigger**
+9. Choose **Upload a ZIP file** for *Code entry type* and select the archive
+downloaded in step 1.
+10. Add a single environment variable named `AV_DEFINITION_S3_BUCKET`
+and set its value to the name of the bucket created to store your AV
+definitions.
+11. Set *Lambda handler* to `update.lambda_handler`
+12. Under *Basic Settings*, set *Timeout* to **5 minutes** and *Memory* to
 **512**
-12. Save and test your function.  If prompted for test data, just use
+13. Save and test your function.  If prompted for test data, just use
 the default provided.
 
 ### AV Scanner Lambda
@@ -125,18 +126,10 @@ the default provided.
 1. Create the archive using the method in the
  [Build from Source](#build-from-source) section.
 2. From the AWS Lambda Dashboard, click **Create function**
-3. Choose **Author from scratch** on the *Select Blueprint* page
-4. Add a new trigger of type **S3 Event** using `ObjectCreate(all)`.
-5. Name your function `bucket-antivirus-function` when prompted on the
-*Configure function* step.
-6. Set *Runtime* to `Python 2.7`
-7. Choose **Upload a ZIP file** for *Code entry type* and select the archive
-created in step 1.
-7. Add a single environment variable named `AV_DEFINITION_S3_BUCKET`
-and set its value to the name of the bucket created to store your AV
-definitions.
-8. Set *Lambda handler* to `scan.lambda_handler`
-9.  Create a new role name `bucket-antivirus-function` that uses the
+3. Choose **Author from scratch** on the *Create function* page
+4. Name your function `bucket-antivirus-function`
+5. Set *Runtime* to `Python 2.7`
+6.  Create a new role name `bucket-antivirus-function` that uses the
 following policy document
 ```json
 {
@@ -161,9 +154,17 @@ following policy document
    ]
 }
 ```
-10. Before finishing, set *Timeout* to **5 minutes** and *Memory* to
+7. Click *next* to head to the Configuration page
+8. Add a new trigger of type **S3 Event** using `ObjectCreate(all)`.
+9. Choose **Upload a ZIP file** for *Code entry type* and select the archive
+created in step 1.
+10. Set *Lambda handler* to `scan.lambda_handler`
+11. Add a single environment variable named `AV_DEFINITION_S3_BUCKET`
+and set its value to the name of the bucket created to store your AV
+definitions.
+12. Under *Basic settings*, set *Timeout* to **5 minutes** and *Memory* to
 **1024**
-11. Save the function.  Testing is easiest performed by uploading a
+13. Save the function.  Testing is easiest performed by uploading a
 file to the bucket configured as the trigger in step 4.
 
 ### S3 Events

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ created in step 1.
 10. Set *Lambda handler* to `scan.lambda_handler`
 11. Add a single environment variable named `AV_DEFINITION_S3_BUCKET`
 and set its value to the name of the bucket created to store your AV
-definitions.
+definitions. If your bucket is `s3://my-bucket`, the value should be `my-bucket`.
 12. Under *Basic settings*, set *Timeout* to **5 minutes** and *Memory* to
 **1024**
 13. Save the function.  Testing is easiest performed by uploading a


### PR DESCRIPTION
The Lambda pages have changed and I found it confusing to follow. This updates the instructions to match how the Lambda pages have changed.