### PR TITLE
Add metadata for filtering in SNS

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -123,7 +123,13 @@ def sns_scan_results(s3_object, result):
     sns_client.publish(
         TargetArn=AV_STATUS_SNS_ARN,
         Message=json.dumps({'default': json.dumps(message)}),
-        MessageStructure="json"
+        MessageStructure="json",
+        MessageAttributes = {
+            AV_STATUS_METADATA: {
+                'DataType': 'String',
+                'StringValue': result
+            }
+    }
     )
 
 


### PR DESCRIPTION
Adds metadata to the SNS message so it can be filtered via a SNS filter policy.

For instance, this policy will only pass messages about infected files to the subscription:

```
{
    "av-status": ["INFECTED"]
}
```