### PR TITLE
Fixing `Can't find shared libraries` error in Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.DS_Store

--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -27,10 +27,12 @@ virtualenv env
 pip install --no-cache-dir -r requirements.txt
 
 pushd /tmp
-yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update
+yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2
 rpm2cpio clamav-0*.rpm | cpio -idmv
 rpm2cpio clamav-lib*.rpm | cpio -idmv
 rpm2cpio clamav-update*.rpm | cpio -idmv
+rpm2cpio json-c*.rpm | cpio -idmv
+rpm2cpio pcre*.rpm | cpio -idmv
 popd
 mkdir -p bin
 cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* bin/.


### PR DESCRIPTION
Added missing packages installation from build_lambda script
- `json-c` 
- `pcre2`