### PR TITLE
Makefile permission fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,15 @@ AMZ_LINUX_VERSION:=2
 current_dir := $(shell pwd)
 container_dir := /opt/app
 circleci := ${CIRCLECI}
+uid := $(shell id -u)
+gid := $(shell id -g)
 
 all: archive
 
 clean:
-	rm -rf compile/lambda.zip
+	rm -rf bin
+	rm -rf build/lambda.zip
+	rm -rf env
 
 archive: clean
 ifeq ($(circleci), true)
@@ -33,6 +37,8 @@ ifeq ($(circleci), true)
 else
 	docker run --rm -ti \
 		-v $(current_dir):$(container_dir) \
+		-e USERID=$(uid) \
+		-e GROUPID=$(gid) \
 		amazonlinux:$(AMZ_LINUX_VERSION) \
 		/bin/bash -c "cd $(container_dir) && ./build_lambda.sh"
 endif

--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -18,6 +18,17 @@ lambda_output_file=/opt/app/build/lambda.zip
 
 set -e
 
+function finish {
+    for d in "bin" "build" "env"; do
+        p="/opt/app/$d"
+        if [ -d "$p" ]; then
+            chown -R $USERID:$GROUPID $p
+        fi
+    done
+}
+
+trap finish INT TERM EXIT
+
 yum update -y
 yum install -y cpio python2-pip yum-utils zip
 yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm


### PR DESCRIPTION
I'm trying to periodically build bucket-antivirus-function with my CI system, and encountered an issue where the `bin`, `build` and `env` directories were owned by root. This caused subsequent builds assigned to the same agent to fail because these directories could not be removed.

These changes pass the UID and GID of the user calling `make` to the container, which then `chowns` the directories when the script exits normally or errors.

I have also added a change so that `make clean` will remove all directories created by the build.