### PR TITLE
freshclam replaces daily.cvd with daily.cld

### DIFF
--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -37,6 +37,7 @@ popd
 mkdir -p bin
 cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* bin/.
 echo "DatabaseMirror database.clamav.net" > bin/freshclam.conf
+echo "CompressLocalDatabase yes" >> bin/freshclam.conf
 
 mkdir -p build
 zip -r9 $lambda_output_file *.py bin

--- a/update.py
+++ b/update.py
@@ -32,6 +32,11 @@ def lambda_handler(event, context):
         if os.path.exists(os.path.join(AV_DEFINITION_PATH, "main.cvd")):
             os.remove(os.path.join(AV_DEFINITION_PATH, "main.cvd"))
         clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
+    # When freshclam applies updates it replaces daily.cvd with daily.cld.
+    # Adding 'CompressLocalDatabase yes' to freshclam.conf ensures this file is compressed
+    # so we can rename daily.cld to daily.cvd and upload it to S3.
+    if os.path.exists(os.path.join(AV_DEFINITION_PATH, "daily.cld")):
+        os.rename(os.path.join(AV_DEFINITION_PATH, "daily.cld"), os.path.join(AV_DEFINITION_PATH, "daily.cvd"))
     clamav.upload_defs_to_s3(AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX, AV_DEFINITION_PATH)
     print("Script finished at %s\n" %
           datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC"))


### PR DESCRIPTION
I found that running `freshclam` was removing the daily.cvd and adding an uncompressed daily.cld file containing the latest virus definitions. This had two effects:

1) The daily.cld grows continuously and eventually the update lambda runs out of space in /tmp
2) daily.cvd is never uploaded to S3, so the definitions are not updated

These changes force `freshclam` to write a compressed local database, and renames `daily.cld` to `daily.cvd` so the definitions are updated.