### PR TITLE
Databases not being updated #51, possibly #11

### DIFF
--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -24,7 +24,9 @@ yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarc
 pip install --no-cache-dir virtualenv
 virtualenv env
 . env/bin/activate
-pip install --no-cache-dir -r requirements.txt
+# This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
+pip install -r requirements.txt
+rm -rf /root/.cache/pip
 
 pushd /tmp
 yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2

--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -39,6 +39,7 @@ popd
 mkdir -p bin
 cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* bin/.
 echo "DatabaseMirror database.clamav.net" > bin/freshclam.conf
+echo "CompressLocalDatabase yes" >> bin/freshclam.conf
 
 mkdir -p build
 zip -r9 $lambda_output_file *.py bin

--- a/clamav.py
+++ b/clamav.py
@@ -128,7 +128,7 @@ def md5_from_s3_tags(bucket, key):
 
 def time_from_s3(bucket, key):
     try:
-        time = s3.Object(bucket, key).last_modified
+        time = s3_client.head_object(Bucket=bucket, Key=key)["LastModified"]
     except botocore.exceptions.ClientError as e:
         expected_errors = {'404', 'AccessDenied', 'NoSuchKey'}
         if e.response['Error']['Code'] in expected_errors:

--- a/clamav_test.py
+++ b/clamav_test.py
@@ -13,16 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import os
 import re
 import textwrap
 import unittest
 
+import boto3
+import botocore.session
+from botocore.stub import Stubber
+import mock
+
 from clamav import RE_SEARCH_DIR
 from clamav import scan_output_to_json
+from clamav import md5_from_s3_tags
+from clamav import time_from_s3
+from clamav import update_defs_from_s3
+from common import AV_DEFINITION_FILE_PREFIXES
+from common import AV_DEFINITION_FILE_SUFFIXES
+from common import AV_DEFINITION_S3_PREFIX
 from common import AV_SIGNATURE_OK
 
 
 class TestClamAV(unittest.TestCase):
+    def setUp(self):
+        # Common data
+        self.s3_bucket_name = "test_bucket"
+        self.s3_key_name = "test_key"
+
+        # Clients and Resources
+        self.s3 = boto3.resource("s3")
+        self.s3_client = botocore.session.get_session().create_client("s3")
+        self.sns_client = botocore.session.get_session().create_client(
+            "sns", region_name="us-west-2"
+        )
+
     def test_current_library_search_path(self):
         # Calling `ld --verbose` returns a lot of text but the line to check is this one:
         search_path = """SEARCH_DIR("=/usr/x86_64-redhat-linux/lib64"); SEARCH_DIR("=/usr/lib64"); SEARCH_DIR("=/usr/local/lib64"); SEARCH_DIR("=/lib64"); SEARCH_DIR("=/usr/x86_64-redhat-linux/lib"); SEARCH_DIR("=/usr/local/lib"); SEARCH_DIR("=/lib"); SEARCH_DIR("=/usr/lib");"""  # noqa
@@ -88,3 +113,240 @@ class TestClamAV(unittest.TestCase):
         summary = scan_output_to_json(output)
         self.assertEqual(summary[file_path], signature)
         self.assertEqual(summary["Infected files"], "1")
+
+    def test_md5_from_s3_tags_no_md5(self):
+        tag_set = {"TagSet": []}
+
+        s3_stubber = Stubber(self.s3_client)
+        get_object_tagging_response = tag_set
+        get_object_tagging_expected_params = {
+            "Bucket": self.s3_bucket_name,
+            "Key": self.s3_key_name,
+        }
+        s3_stubber.add_response(
+            "get_object_tagging",
+            get_object_tagging_response,
+            get_object_tagging_expected_params,
+        )
+        with s3_stubber:
+            md5_hash = md5_from_s3_tags(
+                self.s3_client, self.s3_bucket_name, self.s3_key_name
+            )
+            self.assertEquals("", md5_hash)
+
+    def test_md5_from_s3_tags_has_md5(self):
+        expected_md5_hash = "d41d8cd98f00b204e9800998ecf8427e"
+        tag_set = {"TagSet": [{"Key": "md5", "Value": expected_md5_hash}]}
+
+        s3_stubber = Stubber(self.s3_client)
+        get_object_tagging_response = tag_set
+        get_object_tagging_expected_params = {
+            "Bucket": self.s3_bucket_name,
+            "Key": self.s3_key_name,
+        }
+        s3_stubber.add_response(
+            "get_object_tagging",
+            get_object_tagging_response,
+            get_object_tagging_expected_params,
+        )
+        with s3_stubber:
+            md5_hash = md5_from_s3_tags(
+                self.s3_client, self.s3_bucket_name, self.s3_key_name
+            )
+            self.assertEquals(expected_md5_hash, md5_hash)
+
+    def test_time_from_s3(self):
+
+        expected_s3_time = datetime.datetime(2019, 1, 1)
+
+        s3_stubber = Stubber(self.s3_client)
+        head_object_response = {"LastModified": expected_s3_time}
+        head_object_expected_params = {
+            "Bucket": self.s3_bucket_name,
+            "Key": self.s3_key_name,
+        }
+        s3_stubber.add_response(
+            "head_object", head_object_response, head_object_expected_params
+        )
+        with s3_stubber:
+            s3_time = time_from_s3(
+                self.s3_client, self.s3_bucket_name, self.s3_key_name
+            )
+            self.assertEquals(expected_s3_time, s3_time)
+
+    @mock.patch("clamav.md5_from_file")
+    @mock.patch("common.os.path.exists")
+    def test_update_defs_from_s3(self, mock_exists, mock_md5_from_file):
+        expected_md5_hash = "d41d8cd98f00b204e9800998ecf8427e"
+        different_md5_hash = "d41d8cd98f00b204e9800998ecf8427f"
+
+        mock_md5_from_file.return_value = different_md5_hash
+
+        tag_set = {"TagSet": [{"Key": "md5", "Value": expected_md5_hash}]}
+        expected_s3_time = datetime.datetime(2019, 1, 1)
+
+        s3_stubber = Stubber(self.s3_client)
+
+        key_names = []
+        side_effect = []
+        for file_prefix in AV_DEFINITION_FILE_PREFIXES:
+            for file_suffix in AV_DEFINITION_FILE_SUFFIXES:
+                side_effect.extend([True, True])
+                filename = file_prefix + "." + file_suffix
+                key_names.append(os.path.join(AV_DEFINITION_S3_PREFIX, filename))
+        mock_exists.side_effect = side_effect
+
+        for s3_key_name in key_names:
+            get_object_tagging_response = tag_set
+            get_object_tagging_expected_params = {
+                "Bucket": self.s3_bucket_name,
+                "Key": s3_key_name,
+            }
+            s3_stubber.add_response(
+                "get_object_tagging",
+                get_object_tagging_response,
+                get_object_tagging_expected_params,
+            )
+            head_object_response = {"LastModified": expected_s3_time}
+            head_object_expected_params = {
+                "Bucket": self.s3_bucket_name,
+                "Key": s3_key_name,
+            }
+            s3_stubber.add_response(
+                "head_object", head_object_response, head_object_expected_params
+            )
+
+        expected_to_download = {
+            "bytecode": {
+                "local_path": "/tmp/clamav_defs/bytecode.cvd",
+                "s3_path": "clamav_defs/bytecode.cvd",
+            },
+            "daily": {
+                "local_path": "/tmp/clamav_defs/daily.cvd",
+                "s3_path": "clamav_defs/daily.cvd",
+            },
+            "main": {
+                "local_path": "/tmp/clamav_defs/main.cvd",
+                "s3_path": "clamav_defs/main.cvd",
+            },
+        }
+        with s3_stubber:
+            to_download = update_defs_from_s3(
+                self.s3_client, self.s3_bucket_name, AV_DEFINITION_S3_PREFIX
+            )
+            self.assertEquals(expected_to_download, to_download)
+
+    @mock.patch("clamav.md5_from_file")
+    @mock.patch("common.os.path.exists")
+    def test_update_defs_from_s3_same_hash(self, mock_exists, mock_md5_from_file):
+        expected_md5_hash = "d41d8cd98f00b204e9800998ecf8427e"
+        different_md5_hash = expected_md5_hash
+
+        mock_md5_from_file.return_value = different_md5_hash
+
+        tag_set = {"TagSet": [{"Key": "md5", "Value": expected_md5_hash}]}
+        expected_s3_time = datetime.datetime(2019, 1, 1)
+
+        s3_stubber = Stubber(self.s3_client)
+
+        key_names = []
+        side_effect = []
+        for file_prefix in AV_DEFINITION_FILE_PREFIXES:
+            for file_suffix in AV_DEFINITION_FILE_SUFFIXES:
+                side_effect.extend([True, True])
+                filename = file_prefix + "." + file_suffix
+                key_names.append(os.path.join(AV_DEFINITION_S3_PREFIX, filename))
+        mock_exists.side_effect = side_effect
+
+        for s3_key_name in key_names:
+            get_object_tagging_response = tag_set
+            get_object_tagging_expected_params = {
+                "Bucket": self.s3_bucket_name,
+                "Key": s3_key_name,
+            }
+            s3_stubber.add_response(
+                "get_object_tagging",
+                get_object_tagging_response,
+                get_object_tagging_expected_params,
+            )
+            head_object_response = {"LastModified": expected_s3_time}
+            head_object_expected_params = {
+                "Bucket": self.s3_bucket_name,
+                "Key": s3_key_name,
+            }
+            s3_stubber.add_response(
+                "head_object", head_object_response, head_object_expected_params
+            )
+
+        expected_to_download = {}
+        with s3_stubber:
+            to_download = update_defs_from_s3(
+                self.s3_client, self.s3_bucket_name, AV_DEFINITION_S3_PREFIX
+            )
+            self.assertEquals(expected_to_download, to_download)
+
+    @mock.patch("clamav.md5_from_file")
+    @mock.patch("common.os.path.exists")
+    def test_update_defs_from_s3_old_files(self, mock_exists, mock_md5_from_file):
+        expected_md5_hash = "d41d8cd98f00b204e9800998ecf8427e"
+        different_md5_hash = "d41d8cd98f00b204e9800998ecf8427f"
+
+        mock_md5_from_file.return_value = different_md5_hash
+
+        tag_set = {"TagSet": [{"Key": "md5", "Value": expected_md5_hash}]}
+        expected_s3_time = datetime.datetime(2019, 1, 1)
+
+        s3_stubber = Stubber(self.s3_client)
+
+        key_names = []
+        side_effect = []
+        for file_prefix in AV_DEFINITION_FILE_PREFIXES:
+            for file_suffix in AV_DEFINITION_FILE_SUFFIXES:
+                side_effect.extend([True, True])
+                filename = file_prefix + "." + file_suffix
+                key_names.append(os.path.join(AV_DEFINITION_S3_PREFIX, filename))
+        mock_exists.side_effect = side_effect
+
+        count = 0
+        for s3_key_name in key_names:
+            get_object_tagging_response = tag_set
+            get_object_tagging_expected_params = {
+                "Bucket": self.s3_bucket_name,
+                "Key": s3_key_name,
+            }
+            s3_stubber.add_response(
+                "get_object_tagging",
+                get_object_tagging_response,
+                get_object_tagging_expected_params,
+            )
+            head_object_response = {
+                "LastModified": expected_s3_time - datetime.timedelta(hours=count)
+            }
+            head_object_expected_params = {
+                "Bucket": self.s3_bucket_name,
+                "Key": s3_key_name,
+            }
+            s3_stubber.add_response(
+                "head_object", head_object_response, head_object_expected_params
+            )
+            count += 1
+
+        expected_to_download = {
+            "bytecode": {
+                "local_path": "/tmp/clamav_defs/bytecode.cld",
+                "s3_path": "clamav_defs/bytecode.cld",
+            },
+            "daily": {
+                "local_path": "/tmp/clamav_defs/daily.cld",
+                "s3_path": "clamav_defs/daily.cld",
+            },
+            "main": {
+                "local_path": "/tmp/clamav_defs/main.cld",
+                "s3_path": "clamav_defs/main.cld",
+            },
+        }
+        with s3_stubber:
+            to_download = update_defs_from_s3(
+                self.s3_client, self.s3_bucket_name, AV_DEFINITION_S3_PREFIX
+            )
+            self.assertEquals(expected_to_download, to_download)

--- a/common.py
+++ b/common.py
@@ -32,7 +32,8 @@ FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
 AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv("AV_PROCESS_ORIGINAL_VERSION_ONLY", "False")
 AV_DELETE_INFECTED_FILES = os.getenv("AV_DELETE_INFECTED_FILES", "False")
 
-AV_DEFINITION_FILENAMES = ["main.cvd","daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
+AV_DEFINITION_FILE_PREFIXES = ["main", "daily", "bytecode"]
+AV_DEFINITION_FILE_SUFFIXES = ["cld", "cvd"]
 
 s3 = boto3.resource('s3')
 s3_client = boto3.client('s3')

--- a/common.py
+++ b/common.py
@@ -16,6 +16,7 @@
 import errno
 import datetime
 import os
+import os.path
 
 AV_DEFINITION_S3_BUCKET = os.getenv("AV_DEFINITION_S3_BUCKET")
 AV_DEFINITION_S3_PREFIX = os.getenv("AV_DEFINITION_S3_PREFIX", "clamav_defs")

--- a/common_test.py
+++ b/common_test.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Upside Travel, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import errno
+import unittest
+
+import mock
+
+from common import create_dir
+
+
+class TestCommon(unittest.TestCase):
+    @mock.patch("common.os.path")
+    @mock.patch("common.os")
+    def test_create_dir_already_exists(self, mock_os, mock_path):
+        mock_path.exists.return_value = True
+        create_dir("testpath")
+        self.assertFalse(
+            mock_os.makedirs.called, "Failed to not make directories if path present."
+        )
+
+    @mock.patch("common.os.path")
+    @mock.patch("common.os")
+    def test_create_dir_doesnt_exist(self, mock_os, mock_path):
+        mock_path.exists.return_value = False
+        create_dir("testpath")
+        self.assertTrue(
+            mock_os.makedirs.called, "Failed to make directories if path not present."
+        )
+
+    @mock.patch("common.os.path")
+    @mock.patch("common.os")
+    def test_create_dir_doesnt_exist_no_raises(self, mock_os, mock_path):
+        mock_path.exists.return_value = False
+        mock_os.makedirs.side_effect = OSError(errno.EEXIST, "exists")
+        create_dir("testpath")
+        self.assertTrue(
+            mock_os.makedirs.called, "Failed to make directories if path not present."
+        )
+
+    @mock.patch("common.os.path")
+    @mock.patch("common.os")
+    def test_create_dir_doesnt_exist_but_raises(self, mock_os, mock_path):
+        mock_path.exists.return_value = False
+        mock_os.makedirs.side_effect = OSError(errno.ENAMETOOLONG, "nametoolong")
+        with self.assertRaises(OSError):
+            create_dir("testpath")
+        self.assertTrue(
+            mock_os.makedirs.called, "Failed to make directories if path not present."
+        )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ boto3
 
 # Test requirements
 coverage
+mock==3.0.5
 nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ idna==2.8
 requests==2.21
 simplejson==3.16
 urllib3==1.24.1
+pytz==2018.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ idna==2.8
 requests==2.21
 simplejson==3.16
 urllib3==1.24.1
-pytz==2018.9
+pytz==2019.3

--- a/scan.py
+++ b/scan.py
@@ -222,7 +222,9 @@ def lambda_handler(event, context):
     file_path = get_local_path(s3_object, "/tmp")
     create_dir(os.path.dirname(file_path))
     s3_object.download_file(file_path)
-    clamav.update_defs_from_s3(AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX)
+    clamav.update_defs_from_s3(
+        s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX
+    )
     scan_result, scan_signature = clamav.scan_file(file_path)
     print(
         "Scan of s3://%s resulted in %s\n"


### PR DESCRIPTION
This implements logic to pull only the most up to date database for a type. Each database is an entity with possible different states (cvd, cld, cud). In my findings ".cud" is used purely for unsigned databases, and should not actually be used when referring to the main items used by freshclam (main, daily, bytecode). The main motivation for not treating each database as a different file in every combination (daily.cvd, daily.cld) is databases can get rather large and the run context of lambda is 512mb. During testing if the scanner had access to both a cvd and a cld it would just ignore the older file.