### PR TITLE
adds feature to set destination bucket to move clean files after scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ the table below for reference.
 | FRESHCLAM_PATH | Path to ClamAV freshclam binary | ./bin/freshclam | No |
 | DATADOG_API_KEY | API Key for pushing metrics to DataDog (optional) | | No |
 | AV_PROCESS_ORIGINAL_VERSION_ONLY | Controls that only original version of an S3 key is processed (if bucket versioning is enabled) | False | No |
+| DESTINATION_BUCKET | Clean files will be moved to this bucket in folder named after source bucket |  | No |
+| DESTINATION_PATH | Folder to move files to within destination bucket must add "/" to the end| | No |
 | AV_DELETE_INFECTED_FILES | Controls whether infected files should be automatically deleted | False | No |
 
 ## S3 Bucket Policy Examples

--- a/common.py
+++ b/common.py
@@ -31,6 +31,8 @@ CLAMSCAN_PATH = os.getenv("CLAMSCAN_PATH", "./bin/clamscan")
 FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
 AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv("AV_PROCESS_ORIGINAL_VERSION_ONLY", "False")
 AV_DELETE_INFECTED_FILES = os.getenv("AV_DELETE_INFECTED_FILES", "False")
+DESTINATION_BUCKET = os.getenv("DESTINATION_BUCKET")
+DESTINATION_PATH = os.getenv("DESTINATION_PATH", "")
 
 AV_DEFINITION_FILENAMES = ["main.cvd","daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
 


### PR DESCRIPTION
I ran into a use case where we needed to have multiple source buckets filtered to a single bucket to enter into our dataflow.  I added an s3 move function, environment variables and a couple lines in the main lambda handler function.  When the DESTINATION_BUCKET environment variable is set all files that get CLEAN tags will be moved into a folder named after the initial source bucket in the destination bucket.  If the DESTINATION_PATH environment variable is set that will prefix onto that source folder in the destination bucket.

![image](https://user-images.githubusercontent.com/22945774/53132576-1a7aa300-353e-11e9-9713-56cd6988f994.png)

The above configuration results in the clean file being transferred to a bucket named fl0ffy-destination under "inbox/fl0ffy-source" folders

