### PR TITLE
Sns notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ the [amazonlinux](https://hub.docker.com/_/amazonlinux/) [Docker](https://www.do
 
 Create an s3 bucket to store current antivirus definitions.  This
 provides the fastest download speeds for the scanner.  This bucket can
-be kept as private.  
+be kept as private.
 
 To allow public access, useful for other accounts,
 add the following policy to the bucket.
@@ -205,6 +205,7 @@ the table below for reference.
 | DATADOG_API_KEY | API Key for pushing metrics to DataDog (optional) | | No |
 | AV_PROCESS_ORIGINAL_VERSION_ONLY | Controls that only original version of an S3 key is processed (if bucket versioning is enabled) | False | No |
 | AV_DELETE_INFECTED_FILES | Controls whether infected files should be automatically deleted | False | No |
+| EVENT_SOURCE | The source of antivirus scan event "S3" or "SNS" (optional) | S3 | No |
 
 ## S3 Bucket Policy Examples
 
@@ -213,7 +214,7 @@ This policy doesn't allow to download the object until:
 1) The lambda that run Clam-AV is finished (so the object has a tag)
 2) The file is not CLEAN
 
-Please make sure to check cloudtrail for the arn:aws:sts, just find the event open it and copy the sts.       
+Please make sure to check cloudtrail for the arn:aws:sts, just find the event open it and copy the sts.
 It should be in the format provided below:
 ```
  {
@@ -233,7 +234,7 @@ It should be in the format provided below:
         }
     }
 }
-```   
+```
 
 ### Deny to download and re-tag "INFECTED" object
 ```

--- a/scan.py
+++ b/scan.py
@@ -23,12 +23,14 @@ from datetime import datetime
 from distutils.util import strtobool
 
 ENV = os.getenv("ENV", "")
+EVENT_SOURCE = os.getenv("EVENT_SOURCE", "S3")
 
 
 def event_object(event):
-    message = json.loads(event['Records'][0]['Sns']['Message'])
-    bucket = message['Records'][0]['s3']['bucket']['name']
-    key = urllib.unquote_plus(message['Records'][0]['s3']['object']['key'].encode('utf8'))
+    if EVENT_SOURCE.upper() == "SNS":
+        event = json.loads(event['Records'][0]['Sns']['Message'])
+    bucket = event['Records'][0]['s3']['bucket']['name']
+    key = urllib.unquote_plus(event['Records'][0]['s3']['object']['key'].encode('utf8'))
     if (not bucket) or (not key):
         print("Unable to retrieve object from event.\n%s" % event)
         raise Exception("Unable to retrieve object from event.")

--- a/scan.py
+++ b/scan.py
@@ -26,8 +26,9 @@ ENV = os.getenv("ENV", "")
 
 
 def event_object(event):
-    bucket = event['Records'][0]['s3']['bucket']['name']
-    key = urllib.unquote_plus(event['Records'][0]['s3']['object']['key'].encode('utf8'))
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    bucket = message['Records'][0]['s3']['bucket']['name']
+    key = urllib.unquote_plus(message['Records'][0]['s3']['object']['key'].encode('utf8'))
     if (not bucket) or (not key):
         print("Unable to retrieve object from event.\n%s" % event)
         raise Exception("Unable to retrieve object from event.")


### PR DESCRIPTION
Only one lambda function can listen for s3 event. If someone wants to trigger two or more lambdas on the same s3 event it would be impossible.

One of the solutions is to use SNS topics as trigger events. SNS events have a slightly different structure.