### PR TITLE
Python 3 compatibility and PEP-8 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ this every 3 hours to stay protected from the latest threats.
 3. Choose **Author from scratch** on the *Create function* page
 4. Name your function `bucket-antivirus-update` when prompted on the
 *Configure function* step.
-5. Set *Runtime* to `Python 2.7`
+5. Set *Runtime* to `Python 3.7`
 6.  Create a new role name `bucket-antivirus-update` that uses the
 following policy document
 ```json
@@ -129,7 +129,7 @@ the default provided.
 2. From the AWS Lambda Dashboard, click **Create function**
 3. Choose **Author from scratch** on the *Create function* page
 4. Name your function `bucket-antivirus-function`
-5. Set *Runtime* to `Python 2.7`
+5. Set *Runtime* to `Python 3.7`
 6.  Create a new role name `bucket-antivirus-function` that uses the
 following policy document
 ```json

--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -19,12 +19,12 @@ lambda_output_file=/opt/app/build/lambda.zip
 set -e
 
 yum update -y
-yum install -y cpio python2-pip yum-utils zip
+yum install -y cpio python3-pip yum-utils zip
 yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-pip install --no-cache-dir virtualenv
+pip3 install --no-cache-dir virtualenv
 virtualenv env
 . env/bin/activate
-pip install --no-cache-dir -r requirements.txt
+pip3 install --no-cache-dir -r requirements.txt
 
 pushd /tmp
 yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2
@@ -40,5 +40,5 @@ echo "DatabaseMirror database.clamav.net" > bin/freshclam.conf
 
 mkdir -p build
 zip -r9 $lambda_output_file *.py bin
-cd env/lib/python2.7/site-packages
+cd env/lib/python3.7/site-packages
 zip -r9 $lambda_output_file *

--- a/clamav.py
+++ b/clamav.py
@@ -22,7 +22,7 @@ from subprocess import check_output, Popen, PIPE, STDOUT
 
 
 def current_library_search_path():
-    ld_verbose = check_output(["ld", "--verbose"])
+    ld_verbose = check_output(["ld", "--verbose"]).decode('utf-8')
     rd_ld = re.compile("SEARCH_DIR\(\"([A-z0-9/-]*)\"\)")
     return rd_ld.findall(ld_verbose)
 

--- a/common.py
+++ b/common.py
@@ -32,7 +32,7 @@ FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
 AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv("AV_PROCESS_ORIGINAL_VERSION_ONLY", "False")
 AV_DELETE_INFECTED_FILES = os.getenv("AV_DELETE_INFECTED_FILES", "False")
 
-AV_DEFINITION_FILENAMES = ["main.cvd","daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
+AV_DEFINITION_FILENAMES = ["main.cvd", "daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
 
 s3 = boto3.resource('s3')
 s3_client = boto3.client('s3')


### PR DESCRIPTION
Updated to use Python 3.7, and did some minor PEP-8 compliance changes. 
This should be a drop in replacement, requiring only the AWS runtime to be changed to Python 3.7