### PR TITLE
Allow an empty string as an SNS ARN and ignore it

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -103,7 +103,7 @@ def set_av_tags(s3_object, result):
     )
 
 def sns_start_scan(s3_object):
-    if AV_SCAN_START_SNS_ARN is None:
+    if AV_SCAN_START_SNS_ARN in [None, ""]:
         return
     message = {
         "bucket": s3_object.bucket_name,
@@ -120,7 +120,7 @@ def sns_start_scan(s3_object):
     )
 
 def sns_scan_results(s3_object, result):
-    if AV_STATUS_SNS_ARN is None:
+    if AV_STATUS_SNS_ARN in [None, ""]:
         return
     message = {
         "bucket": s3_object.bucket_name,


### PR DESCRIPTION
This change allows a user to pass in an empty string as an environment variable for the SNS ARN which will have the same effect as not setting that environment variable.

Background: I am setting up this lambda using a terraform module. In terraform I have to list all the environment variables that I might wish to change and some of them end up being empty strings. The `sns_client.publish()` function expects a real SNS ARN and not an empty string or it won't validate. The fix here is to check if the environment variable was set and if so an empty string will be ignored similar to if the environment variable was never set.