### PR TITLE
Update the IAM documentation to be more specific about allowed actions and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ following policy document
             "s3:PutObjectVersionTagging",
          ],
          "Effect":"Allow",
-         "Resource": ["arn:aws:s3:::<bucket-name-1>/*", "arn:aws:s3:::<bucket-name-2>/*"]
+         "Resource": [
+           "arn:aws:s3:::<bucket-name-1>/*",
+           "arn:aws:s3:::<bucket-name-2>/*"
+         ]
       },
       {
          "Action":[
@@ -161,21 +164,29 @@ following policy document
             "s3:GetObjectTagging",
          ],
          "Effect":"Allow",
-         "Resource": ["arn:aws:s3:::<av-definition-s3-bucket>/*"]
+         "Resource": [
+           "arn:aws:s3:::<av-definition-s3-bucket>/*"
+         ]
       },
       {
          "Action":[
             "kms:Decrypt",
          ],
          "Effect":"Allow",
-         "Resource": ["arn:aws:s3:::<bucket-name-1>/*", "arn:aws:s3:::<bucket-name-2>/*"]
+         "Resource": [
+           "arn:aws:s3:::<bucket-name-1>/*",
+           "arn:aws:s3:::<bucket-name-2>/*"
+         ]
       },
       {
          "Action":[
             "sns:Publish",
          ],
          "Effect":"Allow",
-         "Resource": ["arn:aws:sns:::<av-scan-start>", "arn:aws:sns:::<av-status>"]
+         "Resource": [
+           "arn:aws:sns:::<av-scan-start>",
+           "arn:aws:sns:::<av-status>"
+         ]
       }
    ]
 }

--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ following policy document
       },
       {
          "Action":[
+            "s3:GetObject",
+            "s3:GetObjectTagging",
+         ],
+         "Effect":"Allow",
+         "Resource": ["arn:aws:s3:::<av-definition-s3-bucket>/*"]
+      },
+      {
+         "Action":[
             "kms:Decrypt",
          ],
          "Effect":"Allow",

--- a/README.md
+++ b/README.md
@@ -147,10 +147,27 @@ following policy document
       },
       {
          "Action":[
-            "s3:*"
+            "s3:GetObject",
+            "s3:GetObjectTagging",
+            "s3:PutObjectTagging",
+            "s3:PutObjectVersionTagging",
          ],
          "Effect":"Allow",
-         "Resource":"*"
+         "Resource": ["arn:aws:s3:::<bucket-name-1>/*", "arn:aws:s3:::<bucket-name-2>/*"]
+      },
+      {
+         "Action":[
+            "kms:Decrypt",
+         ],
+         "Effect":"Allow",
+         "Resource": ["arn:aws:s3:::<bucket-name-1>/*", "arn:aws:s3:::<bucket-name-2>/*"]
+      },
+      {
+         "Action":[
+            "sns:Publish",
+         ],
+         "Effect":"Allow",
+         "Resource": ["arn:aws:sns:::<av-scan-start>", "arn:aws:sns:::<av-status>"]
       }
    ]
 }


### PR DESCRIPTION
My company doesn't allow me to use actions like `s3:*` and resources like `*` in IAM policy documents. After working out the actions and resources I needed I thought I'd document them back here. I also noticed that the KMS and SNS actions were not listed. KMS is needed to decrypt any objects from encrypted buckets. SNS is required for any SNS topics you publish to.