### PR TITLE
Allow publishing only CLEAN or only INFECTED results

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ extracted and the files inside scanned also
 or INFECTED, along with the date and time of the scan.
 - Object metadata is updated to reflect the result of the scan (optional)
 - Metrics are sent to [DataDog](https://www.datadoghq.com/) (optional)
-- Scan results are published to a SNS topic (optional)
+- Scan results are published to a SNS topic (optional) (Optionally choose to only publish INFECTED results)
 - Files found to be INFECTED are automatically deleted (optional)
 
 ## Installation
@@ -198,6 +198,8 @@ the table below for reference.
 | AV_STATUS_INFECTED | The value assigned to clean items inside of tags/metadata | INFECTED | No |
 | AV_STATUS_METADATA | The tag/metadata name representing file's AV status | av-status | No |
 | AV_STATUS_SNS_ARN | SNS topic ARN to publish scan results (optional) | | No |
+| AV_STATUS_SNS_PUBLISH_CLEAN | Publish AV_STATUS_CLEAN results to AV_STATUS_SNS_ARN | True | No |
+| AV_STATUS_SNS_PUBLISH_INFECTED | Publish AV_STATUS_INFECTED results to AV_STATUS_SNS_ARN | True | No |
 | AV_TIMESTAMP_METADATA | The tag/metadata name representing file's scan time | av-timestamp | No |
 | CLAMAVLIB_PATH | Path to ClamAV library files | ./bin | No |
 | CLAMSCAN_PATH | Path to ClamAV clamscan binary | ./bin/clamscan | No |

--- a/common.py
+++ b/common.py
@@ -25,6 +25,8 @@ AV_STATUS_CLEAN = os.getenv("AV_STATUS_CLEAN", "CLEAN")
 AV_STATUS_INFECTED = os.getenv("AV_STATUS_INFECTED", "INFECTED")
 AV_STATUS_METADATA = os.getenv("AV_STATUS_METADATA", "av-status")
 AV_STATUS_SNS_ARN = os.getenv("AV_STATUS_SNS_ARN")
+AV_STATUS_SNS_PUBLISH_CLEAN = os.getenv("AV_STATUS_SNS_PUBLISH_CLEAN", "True")
+AV_STATUS_SNS_PUBLISH_INFECTED = os.getenv("AV_STATUS_SNS_PUBLISH_INFECTED", "True")
 AV_TIMESTAMP_METADATA = os.getenv("AV_TIMESTAMP_METADATA", "av-timestamp")
 CLAMAVLIB_PATH = os.getenv("CLAMAVLIB_PATH", "./bin")
 CLAMSCAN_PATH = os.getenv("CLAMSCAN_PATH", "./bin/clamscan")
@@ -32,7 +34,7 @@ FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
 AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv("AV_PROCESS_ORIGINAL_VERSION_ONLY", "False")
 AV_DELETE_INFECTED_FILES = os.getenv("AV_DELETE_INFECTED_FILES", "False")
 
-AV_DEFINITION_FILENAMES = ["main.cvd","daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
+AV_DEFINITION_FILENAMES = ["main.cvd", "daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
 
 s3 = boto3.resource('s3')
 s3_client = boto3.client('s3')

--- a/scan.py
+++ b/scan.py
@@ -119,15 +119,16 @@ def sns_start_scan(s3_object):
         MessageStructure="json"
     )
 
+
 def sns_scan_results(s3_object, result):
     # Don't publish if SNS ARN has been supplied
     if AV_STATUS_SNS_ARN is None:
         return
     # Don't publish if result is CLEAN and CLEAN results should not be published
-    if result == AV_STATUS_CLEAN and not AV_STATUS_SNS_PUBLISH_CLEAN:
+    if result == AV_STATUS_CLEAN and not str_to_bool(AV_STATUS_SNS_PUBLISH_CLEAN):
         return
     # Don't publish if result is INFECTED and INFECTED results should not be published
-    if result == AV_STATUS_INFECTED and not AV_STATUS_SNS_PUBLISH_INFECTED:
+    if result == AV_STATUS_INFECTED and not str_to_bool(AV_STATUS_SNS_PUBLISH_INFECTED):
         return
     message = {
         "bucket": s3_object.bucket_name,

--- a/scan.py
+++ b/scan.py
@@ -121,7 +121,7 @@ def sns_start_scan(s3_object):
 
 
 def sns_scan_results(s3_object, result):
-    # Don't publish if SNS ARN has been supplied
+    # Don't publish if SNS ARN has not been supplied
     if AV_STATUS_SNS_ARN is None:
         return
     # Don't publish if result is CLEAN and CLEAN results should not be published

--- a/scan.py
+++ b/scan.py
@@ -120,7 +120,14 @@ def sns_start_scan(s3_object):
     )
 
 def sns_scan_results(s3_object, result):
+    # Don't publish if SNS ARN has been supplied
     if AV_STATUS_SNS_ARN is None:
+        return
+    # Don't publish if result is CLEAN and CLEAN results should not be published
+    if result == AV_STATUS_CLEAN and not AV_STATUS_SNS_PUBLISH_CLEAN:
+        return
+    # Don't publish if result is INFECTED and INFECTED results should not be published
+    if result == AV_STATUS_INFECTED and not AV_STATUS_SNS_PUBLISH_INFECTED:
         return
     message = {
         "bucket": s3_object.bucket_name,


### PR DESCRIPTION
This change allows only publishing to SNS if the scan result is CLEAN or INFECTED. By default it will publish both which was the previous default. 

Background: My company doesn't want to know if the results are CLEAN. They only want notifications if the results are INFECTED which will kick off additional work for our infrastructure team.

The alternative approach I considered was having an SNS topic ARN for CLEAN and one for INFECTED so that they could be treated differently. However this seemed like it would be backwards incompatible and I don't know the project's tolerance for that kind of change.