### PR TITLE
Fix the clean command to remove the right directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ circleci := ${CIRCLECI}
 all: archive
 
 clean:
-	rm -rf compile/lambda.zip
+	rm -rf bin/
+	rm -rf build/
 
 archive: clean
 ifeq ($(circleci), true)


### PR DESCRIPTION
@jaygorrell - noticed that running `make clean` didn't actually do anything for me. This ought to fix it up although its a bit aggressive.