### PR TITLE
Add python and pre-commit tests to the repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,30 @@
-version: 2
-jobs:
-  build:
-    working_directory: ~/src
+############
+#
+# Caches
+#
+# Caches may have a `v1-` prefix, since caches in CircleCI 2.0 are immutable.
+# A prefix provides an easy way to invalidate a cache.  See https://circleci.com/docs/2.0/caching/#clearing-cache
+#
+############
+
+version: "2.1"
+
+executors:
+  primary:
+    resource_class: small
     docker:
       - image: docker:17.05.0-ce
+  primary_test:
+    resource_class: small
+    docker:
+      - image: circleci/python:3.7-stretch
+
+jobs:
+
+  # `build` is used for building the archive
+  build:
+    executor: primary
+    working_directory: ~/src
     steps:
       - setup_remote_docker:
           reusable: true    # default - false
@@ -15,3 +36,64 @@ jobs:
       - run:
           name: Build
           command: make archive
+
+  # `pre_commit_deps` is used for cache pre-commit sources
+  pre_commit_deps:
+    executor: primary_test
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+
+            - run: pip install pre-commit==1.18.3
+      - run: pre-commit install-hooks
+
+      - save_cache:
+          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+          paths:
+            - ~/.cache/pre-commit
+
+  # `pre_commit_test` is used to run pre-commit hooks on all files
+  pre_commit_test:
+    executor: primary_test
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - restore_cache:
+          keys:
+            - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+            - run: pip install pre-commit==1.18.3
+      - run:
+          name: Run pre-commit tests
+          command: pre-commit run --all-files
+
+  # `test` is used to run python tests
+  test:
+    executor: primary_test
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - restore_cache:
+          keys:
+            - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+            - run: pip install -r requirements-dev.txt
+      - run: nosetests
+
+workflows:
+  version: 2
+
+  main:
+    jobs:
+      - pre_commit_deps
+      - pre_commit_test:
+          requires:
+            - pre_commit_deps
+      - test
+      - build:
+          requires:
+            - pre_commit_tests
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Caches
 #
-# Caches may have a `v1-` prefix, since caches in CircleCI 2.0 are immutable.
+# Caches may require a prefix, since caches in CircleCI 2.0 are immutable.
 # A prefix provides an easy way to invalidate a cache.  See https://circleci.com/docs/2.0/caching/#clearing-cache
 #
 ############

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,5 +95,5 @@ workflows:
       - test
       - build:
           requires:
-            - pre_commit_tests
+            - pre_commit_test
             - test

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+tab_width = 2
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+indent_size = 2
+tab_width = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+tab_width = 4

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501,F405
+max-line-length = 120

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "line_length": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD014": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.7
+        exclude: >
+          (?x)^(
+            scripts/gen-docs-index|
+          )$
+
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+      - id: check-ast
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      - id: fix-encoding-pragma
+      - id: flake8
+      - id: trailing-whitespace
+
+  - repo: git://github.com/igorshubovych/markdownlint-cli
+    rev: v0.17.0
+    hooks:
+      - id: markdownlint
+        entry: markdownlint --ignore .github/*.md

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ else
 		/bin/bash -c "cd $(container_dir) && ./build_lambda.sh"
 endif
 
-.PHONY: ensure_pre_commit  ## Ensure that pre-commit hook is installed and kept up to date
-ensure_pre_commit: .git/hooks/pre-commit ## Ensure pre-commit is installed
+.PHONY: pre_commit_install  ## Ensure that pre-commit hook is installed and kept up to date
+pre_commit_install: .git/hooks/pre-commit ## Ensure pre-commit is installed
 .git/hooks/pre-commit: /usr/local/bin/pre-commit
 	pip install pre-commit==1.18.3
 	pre-commit install
@@ -58,5 +58,5 @@ pre_commit_tests: ## Run pre-commit tests
 	pre-commit run --all-files
 
 .PHONY: test
-test: clean
+test: clean  ## Run python tests
 	nosetests

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ these tests are run by CircleCI.
 ### pre-commit Tests
 
 The pre-commit tests ensure that code submitted to this repository meet the standards of the repository. To get started
-with these tests run `make ensure_pre_commit`. This will install the pre-commit tool and then install it in this
+with these tests run `make pre_commit_install`. This will install the pre-commit tool and then install it in this
 repository. Then the github pre-commit hook will run these tests before you commit your code.
 
 To run the tests manually run `make pre_commit_tests` or `pre-commit run -a`.
@@ -335,7 +335,7 @@ to install the developer resources and then run the tests:
 
 ```sh
 pip install -r requirements-dev.txt
-make tests
+make test
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Scan new objects added to any s3 bucket using AWS Lambda. [more details in this 
 - Accesses the end-user’s separate installation of
 open source antivirus engine [ClamAV](http://www.clamav.net/)
 
-## How Does It Work?
+## How It Works
 
-![](../master/images/bucket-antivirus-function.png)
+![architecture-diagram](../master/images/bucket-antivirus-function.png)
 
 - Each time a new object is added to a bucket, S3 invokes the Lambda
 function to scan the object
@@ -79,35 +79,37 @@ this every 3 hours to stay protected from the latest threats.
 4. Name your function `bucket-antivirus-update` when prompted on the
 *Configure function* step.
 5. Set *Runtime* to `Python 2.7`
-6.  Create a new role name `bucket-antivirus-update` that uses the
+6. Create a new role name `bucket-antivirus-update` that uses the
 following policy document
-```json
-{
-   "Version":"2012-10-17",
-   "Statement":[
-      {
-         "Effect":"Allow",
-         "Action":[
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:PutLogEvents"
-         ],
-         "Resource":"*"
-      },
-      {
-         "Action":[
-            "s3:GetObject",
-            "s3:GetObjectTagging",
-            "s3:PutObject",
-            "s3:PutObjectTagging",
-            "s3:PutObjectVersionTagging"
-         ],
-         "Effect":"Allow",
-         "Resource":"arn:aws:s3:::<bucket-name>/*"
-      }
-   ]
-}
-```
+
+    ```json
+    {
+       "Version":"2012-10-17",
+       "Statement":[
+          {
+             "Effect":"Allow",
+             "Action":[
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+             ],
+             "Resource":"*"
+          },
+          {
+             "Action":[
+                "s3:GetObject",
+                "s3:GetObjectTagging",
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging"
+             ],
+             "Effect":"Allow",
+             "Resource":"arn:aws:s3:::<bucket-name>/*"
+          }
+       ]
+    }
+    ```
+
 7. Click next to go to the Configuration page
 8. Add a trigger from the left of **CloudWatch Event** using `rate(3 hours)`
 for the **Schedule expression**.  Be sure to check **Enable trigger**
@@ -130,67 +132,69 @@ the default provided.
 3. Choose **Author from scratch** on the *Create function* page
 4. Name your function `bucket-antivirus-function`
 5. Set *Runtime* to `Python 2.7`
-6.  Create a new role name `bucket-antivirus-function` that uses the
+6. Create a new role name `bucket-antivirus-function` that uses the
 following policy document
-```json
-{
-   "Version":"2012-10-17",
-   "Statement":[
-      {
-         "Effect":"Allow",
-         "Action":[
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:PutLogEvents"
-         ],
-         "Resource":"*"
-      },
-      {
-         "Action":[
-            "s3:GetObject",
-            "s3:GetObjectTagging",
-            "s3:PutObjectTagging",
-            "s3:PutObjectVersionTagging",
-         ],
-         "Effect":"Allow",
-         "Resource": [
-           "arn:aws:s3:::<bucket-name-1>/*",
-           "arn:aws:s3:::<bucket-name-2>/*"
-         ]
-      },
-      {
-         "Action":[
-            "s3:GetObject",
-            "s3:GetObjectTagging",
-         ],
-         "Effect":"Allow",
-         "Resource": [
-           "arn:aws:s3:::<av-definition-s3-bucket>/*"
-         ]
-      },
-      {
-         "Action":[
-            "kms:Decrypt",
-         ],
-         "Effect":"Allow",
-         "Resource": [
-           "arn:aws:s3:::<bucket-name-1>/*",
-           "arn:aws:s3:::<bucket-name-2>/*"
-         ]
-      },
-      {
-         "Action":[
-            "sns:Publish",
-         ],
-         "Effect":"Allow",
-         "Resource": [
-           "arn:aws:sns:::<av-scan-start>",
-           "arn:aws:sns:::<av-status>"
-         ]
-      }
-   ]
-}
-```
+
+    ```json
+    {
+       "Version":"2012-10-17",
+       "Statement":[
+          {
+             "Effect":"Allow",
+             "Action":[
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+             ],
+             "Resource":"*"
+          },
+          {
+             "Action":[
+                "s3:GetObject",
+                "s3:GetObjectTagging",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+             ],
+             "Effect":"Allow",
+             "Resource": [
+               "arn:aws:s3:::<bucket-name-1>/*",
+               "arn:aws:s3:::<bucket-name-2>/*"
+             ]
+          },
+          {
+             "Action":[
+                "s3:GetObject",
+                "s3:GetObjectTagging",
+             ],
+             "Effect":"Allow",
+             "Resource": [
+               "arn:aws:s3:::<av-definition-s3-bucket>/*"
+             ]
+          },
+          {
+             "Action":[
+                "kms:Decrypt",
+             ],
+             "Effect":"Allow",
+             "Resource": [
+               "arn:aws:s3:::<bucket-name-1>/*",
+               "arn:aws:s3:::<bucket-name-2>/*"
+             ]
+          },
+          {
+             "Action":[
+                "sns:Publish",
+             ],
+             "Effect":"Allow",
+             "Resource": [
+               "arn:aws:sns:::<av-scan-start>",
+               "arn:aws:sns:::<av-status>"
+             ]
+          }
+       ]
+    }
+    ```
+
 7. Click *next* to head to the Configuration page
 8. Add a new trigger of type **S3 Event** using `ObjectCreate(all)`.
 9. Choose **Upload a ZIP file** for *Code entry type* and select the archive
@@ -210,13 +214,12 @@ Configure scanning of additional buckets by adding a new S3 event to
 invoke the Lambda function.  This is done from the properties of any
 bucket in the AWS console.
 
-![](../master/images/s3-event.png)
+![s3-event](../master/images/s3-event.png)
 
 Note: If configured to update object metadata, events must only be
 configured for `PUT` and `POST`. Metadata is immutable, which requires
 the function to copy the object over itself with updated metadata. This
 can cause a continuous loop of scanning if improperly configured.
-
 
 ## Configuration
 
@@ -248,13 +251,16 @@ the table below for reference.
 ## S3 Bucket Policy Examples
 
 ### Deny to download the object if not "CLEAN"
+
 This policy doesn't allow to download the object until:
-1) The lambda that run Clam-AV is finished (so the object has a tag)
-2) The file is not CLEAN
+
+1. The lambda that run Clam-AV is finished (so the object has a tag)
+2. The file is not CLEAN
 
 Please make sure to check cloudtrail for the arn:aws:sts, just find the event open it and copy the sts.
 It should be in the format provided below:
-```
+
+```json
  {
     "Effect": "Deny",
     "NotPrincipal": {
@@ -275,7 +281,8 @@ It should be in the format provided below:
 ```
 
 ### Deny to download and re-tag "INFECTED" object
-```
+
+```json
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -308,9 +315,32 @@ This tool will scan all objects that have not been previously scanned in the buc
 asynchronously. As such you'll have to go to your cloudwatch logs to see the scan results or failures. Additionally,
 the script uses the same environment variables you'd use in your lambda so you can configure them similarly.
 
+## Testing
+
+There are two types of tests in this repository. The first is pre-commit tests and the second are python tests. All of
+these tests are run by CircleCI.
+
+### pre-commit Tests
+
+The pre-commit tests ensure that code submitted to this repository meet the standards of the repository. To get started
+with these tests run `make ensure_pre_commit`. This will install the pre-commit tool and then install it in this
+repository. Then the github pre-commit hook will run these tests before you commit your code.
+
+To run the tests manually run `make pre_commit_tests` or `pre-commit run -a`.
+
+### Python Tests
+
+The python tests in this repository use `unittest` and are run via the `nose` utility. To run them you will need
+to install the developer resources and then run the tests:
+
+```sh
+pip install -r requirements-dev.txt
+make tests
+```
+
 ## License
 
-```
+```text
 Upside Travel, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/clamav_test.py
+++ b/clamav_test.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Upside Travel, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import unittest
+
+from clamav import RE_SEARCH_DIR
+
+
+class TestClamAV(unittest.TestCase):
+    def test_current_library_search_path(self):
+        # Calling `ld --verbose` returns a lot of text but the line to check is this one:
+        search_path = """SEARCH_DIR("=/usr/x86_64-redhat-linux/lib64"); SEARCH_DIR("=/usr/lib64"); SEARCH_DIR("=/usr/local/lib64"); SEARCH_DIR("=/lib64"); SEARCH_DIR("=/usr/x86_64-redhat-linux/lib"); SEARCH_DIR("=/usr/local/lib"); SEARCH_DIR("=/lib"); SEARCH_DIR("=/usr/lib");"""  # noqa
+        rd_ld = re.compile(RE_SEARCH_DIR)
+        all_search_paths = rd_ld.findall(search_path)
+        expected_search_paths = [
+            "/usr/x86_64-redhat-linux/lib64",
+            "/usr/lib64",
+            "/usr/local/lib64",
+            "/lib64",
+            "/usr/x86_64-redhat-linux/lib",
+            "/usr/local/lib",
+            "/lib",
+            "/usr/lib",
+        ]
+        self.assertEqual(all_search_paths, expected_search_paths)

--- a/common.py
+++ b/common.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Upside Travel, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import boto3
 import errno
 import os
 
@@ -43,9 +43,6 @@ AV_DEFINITION_FILENAMES = [
     "bytecode.cvd",
     "bytecode.cud",
 ]
-
-s3 = boto3.resource("s3")
-s3_client = boto3.client("s3")
 
 
 def create_dir(path):

--- a/display_infected.py
+++ b/display_infected.py
@@ -18,6 +18,8 @@
 import argparse
 import sys
 
+import boto3
+
 from common import *  # noqa
 
 

--- a/display_infected.py
+++ b/display_infected.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # Upside Travel, Inc.
 #
@@ -16,11 +17,12 @@
 
 import argparse
 import sys
+
 from common import *  # noqa
 
 
 # Get all objects in an S3 bucket that are infected
-def get_objects(s3_bucket_name):
+def get_objects(s3_client, s3_bucket_name):
 
     s3_object_list = []
 
@@ -36,14 +38,14 @@ def get_objects(s3_bucket_name):
         for key in s3_list_objects_result["Contents"]:
             key_name = key["Key"]
             # Include only infected objects
-            if object_infected(s3_bucket_name, key_name):
+            if object_infected(s3_client, s3_bucket_name, key_name):
                 s3_object_list.append(key_name)
 
     return s3_object_list
 
 
 # Determine if an object has been previously scanned for viruses
-def object_infected(s3_bucket_name, key_name):
+def object_infected(s3_client, s3_bucket_name, key_name):
     s3_object_tags = s3_client.get_object_tagging(Bucket=s3_bucket_name, Key=key_name)
     if "TagSet" not in s3_object_tags:
         return False
@@ -58,6 +60,7 @@ def object_infected(s3_bucket_name, key_name):
 def main(s3_bucket_name):
 
     # Verify the S3 bucket exists
+    s3_client = boto3.client("s3")
     try:
         s3_client.head_bucket(Bucket=s3_bucket_name)
     except Exception:
@@ -65,7 +68,7 @@ def main(s3_bucket_name):
         sys.exit(1)
 
     # Scan the objects in the bucket
-    s3_object_list = get_objects(s3_bucket_name)
+    s3_object_list = get_objects(s3_client, s3_bucket_name)
     for key_name in s3_object_list:
         print("Infected: {}/{}".format(s3_bucket_name, key_name))
 

--- a/metrics.py
+++ b/metrics.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Upside Travel, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datadog
 import os
+
+import datadog
 from common import *  # noqa
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+boto3
+nose

--- a/scan_bucket.py
+++ b/scan_bucket.py
@@ -18,6 +18,9 @@
 import argparse
 import json
 import sys
+
+import boto3
+
 from common import *  # noqa
 
 

--- a/scan_bucket.py
+++ b/scan_bucket.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # Upside Travel, Inc.
 #
@@ -21,7 +22,7 @@ from common import *  # noqa
 
 
 # Get all objects in an S3 bucket that have not been previously scanned
-def get_objects(s3_bucket_name):
+def get_objects(s3_client, s3_bucket_name):
 
     s3_object_list = []
 
@@ -37,14 +38,14 @@ def get_objects(s3_bucket_name):
         for key in s3_list_objects_result["Contents"]:
             key_name = key["Key"]
             # Don't include objects that have been scanned
-            if not object_previously_scanned(s3_bucket_name, key_name):
+            if not object_previously_scanned(s3_client, s3_bucket_name, key_name):
                 s3_object_list.append(key_name)
 
     return s3_object_list
 
 
 # Determine if an object has been previously scanned for viruses
-def object_previously_scanned(s3_bucket_name, key_name):
+def object_previously_scanned(s3_client, s3_bucket_name, key_name):
     s3_object_tags = s3_client.get_object_tagging(Bucket=s3_bucket_name, Key=key_name)
     if "TagSet" not in s3_object_tags:
         return False
@@ -90,6 +91,7 @@ def main(lambda_function_name, s3_bucket_name, limit):
         sys.exit(1)
 
     # Verify the S3 bucket exists
+    s3_client = boto3.client("s3")
     try:
         s3_client.head_bucket(Bucket=s3_bucket_name)
     except Exception:
@@ -97,7 +99,7 @@ def main(lambda_function_name, s3_bucket_name, limit):
         sys.exit(1)
 
     # Scan the objects in the bucket
-    s3_object_list = get_objects(s3_bucket_name)
+    s3_object_list = get_objects(s3_client, s3_bucket_name)
     if limit:
         s3_object_list = s3_object_list[: min(limit, len(s3_object_list))]
     for key_name in s3_object_list:

--- a/update.py
+++ b/update.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Upside Travel, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import clamav
-from common import *  # noqa
 from datetime import datetime
 import os
+
+import clamav
+from common import *  # noqa
 
 
 def lambda_handler(event, context):


### PR DESCRIPTION
@jaygorrell - I promised I'd write tests for you and I have.

This PR adds two types of tests: 1) python, 2) pre-commit.

The python tests are super minimal. I attacked an issue my linter saw with the regex for looking at the library paths inside the lambda. Its a great starting point for adding more tests.

The [pre-commit tests](https://pre-commit.com/) use the `.pre-commit-config.yaml` to run a series of checks on code before it is committed. You can read about each set of tests and I've tried to only include things that would affect this library and the code within it.

I've used pre-commit to clean up the python and markdown files. 

Finally, I've added updates to CircleCI that run both of these tests. I don't believe I have the ability to check if CircleCI configuration works in the way I've set it up but it mimics a configuration I use for other python repositories at my company. 

I think after working out the kinks in this PR you'll be able to ask future contributors to include python tests and you'll be assured that the code meets a standard your company desires.

-----

Some new `make` targets were added. Start by running `make help` to see what's there!  It works by using a special tagging preceded by `##` to generate the lines.

The other commands you can try are:
- `make pre_commit_install`
- `make pre_commit_tests`
- `make test`