### PR TITLE
fixed clamav.py datetime fromtimestamp function and update policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,14 @@ following policy document
                 "s3:GetObjectTagging",
                 "s3:PutObject",
                 "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging"
+                "s3:PutObjectVersionTagging",
+                "s3:ListBucket"
              ],
              "Effect":"Allow",
-             "Resource":"arn:aws:s3:::<bucket-name>/*"
+             "Resource":[
+                "arn:aws:s3:::<bucket-name>",
+                "arn:aws:s3:::<bucket-name>/*"
+             ]
           }
        ]
     }

--- a/clamav.py
+++ b/clamav.py
@@ -165,7 +165,7 @@ def time_from_s3(s3_client, bucket, key):
     except botocore.exceptions.ClientError as e:
         expected_errors = {"404", "AccessDenied", "NoSuchKey"}
         if e.response["Error"]["Code"] in expected_errors:
-            return datetime.fromtimestamp(0, utc)
+            return datetime.datetime.fromtimestamp(0, utc)
         else:
             raise
     return time


### PR DESCRIPTION
There was two bugs preventing first run of the bucket antivirus definition update function:

1. according to https://stackoverflow.com/a/52508192/3476100 , if `HeadObject` is called on a nonexisting object, a different error will be raised depending on `s3:ListBucket` permission on the bucket. Solution to prevent update function from running into `An error occurred (403) when calling the HeadObject operation: Forbidden` is to allow the function the `s3:ListBucket` action on the bucket

2. The PR #63 introduced a bug when treating the exception from `head_object`. It is supposed to return a default timestamp when no object exists, but `fromtimestamp` is not actually a method from `datetime` but `datetime.datetime`

With those 2 corrections, the update function works again with first run.