### PR TITLE
The bucket is not included in the logs

### DIFF
--- a/update.py
+++ b/update.py
@@ -37,7 +37,7 @@ def lambda_handler(event, context):
     for download in to_download.values():
         s3_path = download["s3_path"]
         local_path = download["local_path"]
-        print("Downloading definition file %s from s3://%s" % (local_path, s3_path))
+        print("Downloading definition file %s from s3://%s/%s" % (local_path, AV_DEFINITION_S3_BUCKET, s3_path))
         s3.Bucket(AV_DEFINITION_S3_BUCKET).download_file(s3_path, local_path)
         print("Downloading definition file %s complete!" % (local_path))
 


### PR DESCRIPTION
There's a small log line which misses out the bucket, so you get:

> Downloading definition file /tmp/clamav_defs/main.cvd from s3://clamav_defs/main.cvd

Instead of:

> Downloading definition file /tmp/clamav_defs/main.cvd from s3://our-bucket/clamav_defs/main.cvd

This changes that :)
