### PR TITLE
Docker build speedup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,20 @@ RUN mkdir -p /opt/app
 RUN mkdir -p /opt/app/build
 RUN mkdir -p /opt/app/bin/
 
-# Copy in the lambda source
-WORKDIR /opt/app
-COPY ./*.py /opt/app/
-COPY requirements.txt /opt/app/requirements.txt
-
 # Install packages
 RUN yum update -y
 RUN yum install -y cpio python3-pip yum-utils zip unzip less
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# Install requirements
+WORKDIR /opt/app
+COPY requirements.txt /opt/app/requirements.txt
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
 RUN pip3 install -r requirements.txt
 RUN rm -rf /root/.cache/pip
+
+# Copy in the lambda source
+COPY ./*.py /opt/app/
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ clean:  ## Clean build artifacts
 	find ./ -type d -name '__pycache__' -delete
 	find ./ -type f -name '*.pyc' -delete
 
+.PHONY: cleandocker
+cleandocker: clean
+	docker rmi bucket-antivirus-function:latest
+
 .PHONY: archive
 archive: clean  ## Create the archive for AWS lambda
 	docker build -t bucket-antivirus-function:latest .


### PR DESCRIPTION
Small change to Dockerfile layer ordering. Layers which are expected to change infrequently appear earlier in the Dockerfile, reducing the time to `make archive` for code changes. A `make cleandocker` target has been added to the Makefile to explicitly delete the docker image when seeking to build from scratch.

The original ordering may have been intentional (as a way of forcing fresh docker images on every code change), this is just intended to make development quicker. Feel free to close without verbose commentary if so.