### PR TITLE
Add prefix to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,12 @@ This tool will scan all objects that have not been previously scanned in the buc
 asynchronously. As such you'll have to go to your cloudwatch logs to see the scan results or failures. Additionally,
 the script uses the same environment variables you'd use in your lambda so you can configure them similarly.
 
+If you want to scan a subset of the bucket (or even a single object) you can use the `--prefix` option to filter objects. Remember that S3 objects are not real paths and prefixes match on substrings, so `--prefix=test` will match objects named `test`, `testfoo`, and `testing/foo`:
+
+```sh
+scan_bucket.py --lambda-function-name=<lambda_function_name> --s3-bucket-name=<s3-bucket-to-scan> --prefix=path/to/files/
+```
+
 ## Testing
 
 There are two types of tests in this repository. The first is pre-commit tests and the second are python tests. All of


### PR DESCRIPTION
Adds `--prefix` argument to `scan_bucket.py` and `display_infected.py` to limit the objects considered for each.

For buckets with many (>100,000) the `scan_bucket.py` and `display_infected.py` scripts can incur long running times and non-negligible API costs to iterate an entire bucket. The `--prefix` option passes a string to the [ListObjectsV2](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Paginator.ListObjectsV2) Prefix parameter which limits the objects to iterate and consider.

**Note:** the long runtime/incurred costs issue remains present in the existing `--limit` argument as it currently iterates the entire bucket before trimming the returned objects with a Python slice. I'm making these patches on a contract job so I don't have time to fix the pagination logic for this issue. Please advise if you'd like a separate issue to track.