### PR TITLE
Display bucket name in log statement when downloading definition

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -230,7 +230,7 @@ def lambda_handler(event, context):
     for download in to_download.values():
         s3_path = download["s3_path"]
         local_path = download["local_path"]
-        print("Downloading definition file %s from s3://%s" % (local_path, s3_path))
+        print("Downloading definition file %s from s3://%s/%s" % (local_path, AV_DEFINITION_S3_BUCKET, s3_path))
         s3.Bucket(AV_DEFINITION_S3_BUCKET).download_file(s3_path, local_path)
         print("Downloading definition file %s complete!" % (local_path))
     scan_result, scan_signature = clamav.scan_file(file_path)

--- a/update.py
+++ b/update.py
@@ -37,7 +37,7 @@ def lambda_handler(event, context):
     for download in to_download.values():
         s3_path = download["s3_path"]
         local_path = download["local_path"]
-        print("Downloading definition file %s from s3://%s" % (local_path, s3_path))
+        print("Downloading definition file %s from s3://%s/%s" % (local_path, AV_DEFINITION_S3_BUCKET, s3_path))
         s3.Bucket(AV_DEFINITION_S3_BUCKET).download_file(s3_path, local_path)
         print("Downloading definition file %s complete!" % (local_path))
 


### PR DESCRIPTION
Hi,

When using the tool I was confused by the following log message:
```
Downloading definition file /tmp/clamav_defs/main.cvd from s3://clamav_defs/main.cvd
```
At first I thought the definition was being downloaded from a bucket that was not mine.
This PR is about including the bucket name in that log message.

Signed-off-by: Jean-Baptiste Le Duigou <jb.leduigou@gmail.com>