### PR TITLE
missing prelude library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt /opt/app/requirements.txt
 
 # Install packages
 RUN yum update -y
-RUN yum install -y cpio python3-pip yum-utils zip unzip less
+RUN yum install -y cpio python3-pip yum-utils zip unzip less libprelude
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
@@ -21,12 +21,13 @@ RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2
+RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libprelude
 RUN rpm2cpio clamav-0*.rpm | cpio -idmv
 RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
 RUN rpm2cpio clamav-update*.rpm | cpio -idmv
 RUN rpm2cpio json-c*.rpm | cpio -idmv
 RUN rpm2cpio pcre*.rpm | cpio -idmv
+RUN rpm2cpio libprelude*.rpm | cpio -idmv
 
 # Copy over the binaries and libraries
 RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /opt/app/bin/


### PR DESCRIPTION
Building off of master yesterday and running, resulted in this error

```text
2021-01-05T14:43:32.573-06:00	./bin/clamscan: error while loading shared libraries: libprelude.so.28: cannot open shared object file: No such file or directory
	2021-01-05T14:43:32.573-06:00	Unexpected exit code from clamscan: 127. 
```

This PR fixes it and allows the scan to complete successfully.