### PR TITLE
Detect encoding of clamav process output and decode accordingly

### DIFF
--- a/clamav.py
+++ b/clamav.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import chardet
 import datetime
 import hashlib
 import os
@@ -183,6 +184,14 @@ def scan_output_to_json(output):
             summary[key] = value.strip()
     return summary
 
+# Detect the most likely character encoding of input
+def detect_encoding(line):
+    chardet_encoding = chardet.detect(line)
+    print("Most likely encoding: %s" % chardet_encoding)
+    if chardet_encoding['confidence'] > 0.8
+        return chardet_encoding['encoding']
+    else
+        return None
 
 def scan_file(path):
     av_env = os.environ.copy()
@@ -194,7 +203,9 @@ def scan_file(path):
         stdout=subprocess.PIPE,
         env=av_env,
     )
-    output = av_proc.communicate()[0].decode()
+    result = av_proc.communicate()[0]
+    result_encoding = detect_encoding(result)
+    output = result.decode(result_encoding) if result_encoding is not None else result.decode('utf-8')
     print("clamscan output:\n%s" % output)
 
     # Turn the output into a data source we can read

--- a/clamav.py
+++ b/clamav.py
@@ -184,14 +184,16 @@ def scan_output_to_json(output):
             summary[key] = value.strip()
     return summary
 
+
 # Detect the most likely character encoding of input
 def detect_encoding(line):
     chardet_encoding = chardet.detect(line)
     print("Most likely encoding: %s" % chardet_encoding)
-    if chardet_encoding['confidence'] > 0.8
+    if chardet_encoding['confidence'] > 0.8:
         return chardet_encoding['encoding']
-    else
+    else:
         return None
+
 
 def scan_file(path):
     av_env = os.environ.copy()


### PR DESCRIPTION


#142 mentions the following error getting returned intermittently:
```
[ERROR] UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe0 in position 276: invalid continuation byte
Traceback (most recent call last):
File "/var/task/scan.py", line 236, in lambda_handler
scan_result, scan_signature = clamav.scan_file(file_path)
File "/var/task/clamav.py", line 195, in scan_file
output = av_proc.communicate()[0].decode()
```

**Challenge:** The av_proc.communicate() method returns the output of the `clamscan` call, but sometimes that output is using a different charset than the default utf-8 used by `decode()`.

As a workaround, this PR will use chardet to try to determine the charset and decode accordingly.

In issue #183, removing the `-a` flag from the `clamscan` call is mentioned as a possible workaround, but I have not tried this.
