### PR TITLE
Run Lambda only for ObjectCreated events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ tmp/
 
 # EICAR Files
 *eicar*
+/.aws-sam/

--- a/Makefile
+++ b/Makefile
@@ -72,15 +72,15 @@ update: ./build/lambda.zip ## Run update function locally
 .PHONY: deploy_stack
 deploy_stack:
 	@echo "Deploying $(AV_LAMBDA_STACK_NAME) stack"
-	aws cloudformation deploy --template-file $(CLOUDFORMATION_LOC) --stack-name $(AV_LAMBDA_STACK_NAME) --parameters ParameterKey=SourceBucket,ParameterValue=$(BUCKET_NAME) --capabilities CAPABILITY_NAMED_IAM
+	aws --profile $(AWS_PROFILE) --region us-east-1 cloudformation deploy --template-file $(CLOUDFORMATION_LOC) --stack-name $(AV_LAMBDA_STACK_NAME) --parameter-overrides SourceBucket=$(BUCKET_NAME) --capabilities CAPABILITY_NAMED_IAM
 
 .PHONY: upload_lambda
 upload_lambda:
 	@echo "Uploading $(LAMBDA_ZIP_LOC) to 'avScanner' Lambda function"
-	aws lambda update-function-code --function-name avScanner --zip-file fileb://$(LAMBDA_ZIP_LOC)
+	aws --profile $(AWS_PROFILE) --region us-east-1 lambda update-function-code --function-name avScanner --zip-file fileb://$(LAMBDA_ZIP_LOC)
 
 	@echo "Uploading $(LAMBDA_ZIP_LOC) to 'avUpdateDefinitions' Lambda function"
-	aws lambda update-function-code --function-name avUpdateDefinitions --zip-file fileb://$(LAMBDA_ZIP_LOC)
+	aws --profile $(AWS_PROFILE) --region us-east-1 lambda update-function-code --function-name avUpdateDefinitions --zip-file fileb://$(LAMBDA_ZIP_LOC)
 
 .PHONY: deploy
 deploy: deploy_stack upload_lambda
@@ -88,4 +88,4 @@ deploy: deploy_stack upload_lambda
 .PHONY: destroy
 destroy:
 	@echo "Destroying $(AV_LAMBDA_STACK_NAME) stack"
-	aws cloudformation delete-stack --stack-name $(AV_LAMBDA_STACK_NAME)
+	aws --profile $(AWS_PROFILE) --region us-east-1 cloudformation delete-stack --stack-name $(AV_LAMBDA_STACK_NAME)

--- a/README.md
+++ b/README.md
@@ -41,23 +41,28 @@ the [amazonlinux](https://hub.docker.com/_/amazonlinux/) [Docker](https://www.do
 
 ### Create Relevant AWS Infra via CloudFormation
 
-Use CloudFormation with the `cloudformation.yaml` located in the `deploy/` directory to quickly spin up the AWS infra needed to run this project. CloudFormation will create:
+Use CloudFormation with the `cloudformation.yaml` located in the `deploy/` directory to quickly spin up the AWS infra needed to run this project.
+Set `BUCKET_NAME` env variable and run `make deploy` to deploy defined resources from `cloudformation.yaml`.
+
+CloudFormation will create:
 
 - An S3 bucket that will store AntiVirus definitions.
 - A Lambda Function called `avUpdateDefinitions` that will update the AV Definitions in the S3 Bucket every 3 hours.
 This function accesses the user’s above S3 Bucket to download updated definitions using `freshclam`.
 - A Lambda Function called `avScanner` that is triggered on each new S3 object creation which scans the object and tags it appropriately. It is created with `1600mb` of memory which should be enough, however if you start to see function timeouts, this memory may have to be bumped up. In the past, we recommended using `1024mb`, but that has started causing Lambda timeouts and bumping this memory has resolved it.
 
-Running CloudFormation, it will ask for 2 inputs for this stack:
+[//]: # (Running CloudFormation, it will ask for 2 inputs for this stack:)
 
-1. BucketType: `private` (default) or `public`. This is applied to the S3 bucket that stores the AntiVirus definitions. We recommend to only use `public` when other AWS accounts need access to this bucket.
-2. SourceBucket: [a non-empty string]. The name (do not include `s3://`) of the S3 bucket that will have its objects scanned. _Note - this is just used to create the IAM Policy, you can add/change source buckets later via the IAM Policy that CloudFormation outputs_
+[//]: # ()
+[//]: # (1. BucketType: `private` &#40;default&#41; or `public`. This is applied to the S3 bucket that stores the AntiVirus definitions. We recommend to only use `public` when other AWS accounts need access to this bucket.)
 
-After the Stack has successfully created, there are 3 manual processes that still have to be done:
+[//]: # (2. SourceBucket: [a non-empty string]. The name &#40;do not include `s3://`&#41; of the S3 bucket that will have its objects scanned. _Note - this is just used to create the IAM Policy, you can add/change source buckets later via the IAM Policy that CloudFormation outputs_)
 
-1. Upload the `build/lambda.zip` file that was created by running `make all` to the `avUpdateDefinitions` and `avScanner` Lambda functions via the Lambda Console.
-2. To trigger the Scanner function on new S3 objects, go to the `avScanner` Lambda function console, navigate to `Configuration` -> `Trigger` -> `Add Trigger` -> Search for S3, and choose your bucket(s) and select `All object create events`, then click `Add`. _Note - if you chose more than 1 bucket as the source, or chose a different bucket than the Source Bucket in the CloudFormation parameter, you will have to also edit the IAM Role to reflect these new buckets (see "Adding or Changing Source Buckets")_
-3. Navigate to the `avUpdateDefinitions` Lambda function and manually trigger the function to get the initial Clam definitions in the bucket (instead of waiting for the 3 hour trigger to happen). Do this by clicking the `Test` section, and then clicking the orange `test` button. The function should take a few seconds to execute, and when finished you should see the `clam_defs` in the `av-definitions` S3 bucket.
+After the Stack has successfully created, there are 2 manual processes that still have to be done:
+
+[//]: # (1. Upload the `build/lambda.zip` file that was created by running `make all` to the `avUpdateDefinitions` and `avScanner` Lambda functions via the Lambda Console.)
+1. To trigger the Scanner function on new S3 objects, go to the `avScanner` Lambda function console, navigate to `Configuration` -> `Trigger` -> `Add Trigger` -> Search for S3, and choose your bucket(s) and select `All object create events`, then click `Add`. _Note - if you chose more than 1 bucket as the source, or chose a different bucket than the Source Bucket in the CloudFormation parameter, you will have to also edit the IAM Role to reflect these new buckets (see "Adding or Changing Source Buckets")_
+2. Navigate to the `avUpdateDefinitions` Lambda function and manually trigger the function to get the initial Clam definitions in the bucket (instead of waiting for the 3 hour trigger to happen). Do this by clicking the `Test` section, and then clicking the orange `test` button. The function should take a few seconds to execute, and when finished you should see the `clam_defs` in the `av-definitions` S3 bucket.
 
 #### Adding or Changing Source Buckets
 
@@ -75,6 +80,10 @@ Note: If configured to update object metadata, events must only be
 configured for `PUT` and `POST`. Metadata is immutable, which requires
 the function to copy the object over itself with updated metadata. This
 can cause a continuous loop of scanning if improperly configured.
+
+## Destroy created AWS resources
+
+Destroying created AWS resources can be done by running `make destroy` (Note: To avoid errors while destroying the AWS resources make sure that S3 bucket `antivirus-definitions-<stack_id>` has been deleted manually.)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the [amazonlinux](https://hub.docker.com/_/amazonlinux/) [Docker](https://www.do
 ### Create Relevant AWS Infra via CloudFormation
 
 Use CloudFormation with the `cloudformation.yaml` located in the `deploy/` directory to quickly spin up the AWS infra needed to run this project.
-Set `BUCKET_NAME` env variable and run `make deploy` to deploy defined resources from `cloudformation.yaml`.
+Set `BUCKET_NAME` and `AWS_PROFILE` env variables and run `make deploy` to deploy defined resources from `cloudformation.yaml`.
 
 CloudFormation will create:
 

--- a/deploy/cloudformation.yaml
+++ b/deploy/cloudformation.yaml
@@ -16,7 +16,7 @@
     SourceBucket:
       Type: String
       Description: Name of the source bucket whose objects will be scanned. If more than one source bucket, the others will have to be manually added to the AV Scanner Policy after creation.
-      Default: "<source-bucket>"
+      Default: "<source-bucket-name>"
       AllowedPattern : ".+"
 
   Conditions:

--- a/scan.py
+++ b/scan.py
@@ -55,6 +55,10 @@ def event_object(event, event_source="s3"):
         raise Exception("No records found in event!")
     record = records[0]
 
+    if "ObjectCreated" not in record.get("eventName", ''):
+        print("Skipping non-ObjectCreated event types")
+        return None
+
     s3_obj = record["s3"]
 
     # Get the bucket name
@@ -212,6 +216,10 @@ def lambda_handler(event, context):
     start_time = get_timestamp()
     print("Script starting at %s\n" % (start_time))
     s3_object = event_object(event, event_source=EVENT_SOURCE)
+
+    # If event_type is not 'ObjectCreated' escape lambda
+    if s3_object is None:
+        return
 
     if str_to_bool(AV_PROCESS_ORIGINAL_VERSION_ONLY):
         verify_s3_object_version(s3, s3_object)


### PR DESCRIPTION
The PR should resolve this:
https://github.com/solvebio/api.solvebio.com/issues/3205#:~:text=The%20lambda%20does%20not%20filter%20based%20on%20the%20event%20type%2C%20so%20we%20get%20an%20infinite%20loop%20when%20the%20AV%20lambda%20tags%20something%20and%20then%20receives%20the%20SNS%20event%20for%20that%20tag%20event.%20It%20should%20filter%20and%20run%20only%20on%20s3%3AObjectCreated%20events