### PR TITLE
update build script to use amd64 platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ tmp/
 
 # EICAR Files
 *eicar*
+
+# VSCode
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,17 @@ RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2
+RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libprelude gnutls libtasn1 lib64nettle nettle
 RUN rpm2cpio clamav-0*.rpm | cpio -idmv
 RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
 RUN rpm2cpio clamav-update*.rpm | cpio -idmv
 RUN rpm2cpio json-c*.rpm | cpio -idmv
 RUN rpm2cpio pcre*.rpm | cpio -idmv
+RUN rpm2cpio gnutls* | cpio -idmv
+RUN rpm2cpio nettle* | cpio -idmv
+RUN rpm2cpio lib* | cpio -idmv
+RUN rpm2cpio *.rpm | cpio -idmv
+RUN rpm2cpio libtasn1* | cpio -idmv
 
 # Copy over the binaries and libraries
 RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /opt/app/bin/

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ clean:  ## Clean build artifacts
 
 .PHONY: archive
 archive: clean  ## Create the archive for AWS lambda
-	docker build -t bucket-antivirus-function:latest .
+	docker build --platform linux/amd64 -t bucket-antivirus-function:latest .
 	mkdir -p ./build/
-	docker run -v $(current_dir)/build:/opt/mount --rm --entrypoint cp bucket-antivirus-function:latest /opt/app/build/lambda.zip /opt/mount/lambda.zip
+	docker run --platform linux/amd64 -v $(current_dir)/build:/opt/mount --rm --entrypoint cp bucket-antivirus-function:latest /opt/app/build/lambda.zip /opt/mount/lambda.zip
 
 .PHONY: pre_commit_install  ## Ensure that pre-commit hook is installed and kept up to date
 pre_commit_install: .git/hooks/pre-commit ## Ensure pre-commit is installed

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ the table below for reference.
 | AV_PROCESS_ORIGINAL_VERSION_ONLY | Controls that only original version of an S3 key is processed (if bucket versioning is enabled) | False | No |
 | AV_DELETE_INFECTED_FILES | Controls whether infected files should be automatically deleted | False | No |
 | EVENT_SOURCE | The source of antivirus scan event "S3" or "SNS" (optional) | S3 | No |
+| AV_UPDATE_METADATA | Whether copy the object with new metadata (optional) | False | No |
+
 
 ## S3 Bucket Policy Examples
 

--- a/common.py
+++ b/common.py
@@ -41,6 +41,8 @@ AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv(
 )
 AV_DELETE_INFECTED_FILES = os.getenv("AV_DELETE_INFECTED_FILES", "False")
 
+AV_UPDATE_METADATA = os.getenv("AV_UPDATE_METADATA", "False")
+
 AV_DEFINITION_FILE_PREFIXES = ["main", "daily", "bytecode"]
 AV_DEFINITION_FILE_SUFFIXES = ["cld", "cvd"]
 
@@ -48,7 +50,7 @@ AV_DEFINITION_FILE_SUFFIXES = ["cld", "cvd"]
 def create_dir(path):
     if not os.path.exists(path):
         try:
-            print("Attempting to create directory %s.\n" % path)
+            print("Attempting to create directory: %s\n" % path)
             os.makedirs(path)
         except OSError as exc:
             if exc.errno != errno.EEXIST:

--- a/scan.py
+++ b/scan.py
@@ -200,7 +200,7 @@ def sns_scan_results(
 
 
 def lambda_handler(event, context):
-    print("Received event: " + json.dumps(event, indent=2))
+    print("Received event: " + json.dumps(event))
     s3 = boto3.resource("s3")
     s3_client = boto3.client("s3")
     sns_client = boto3.client("sns")


### PR DESCRIPTION
If no flag provided the default platform is used. 
For M1 machines it's arm64/v8, not amd64 like for most other devices. 
This change will allow to run Makefile on M1 machine without affecting everyone else.